### PR TITLE
Fix typo in List Subcollections of a Document

### DIFF
--- a/firestore/main/index.js
+++ b/firestore/main/index.js
@@ -564,7 +564,7 @@ function getCollections(db) {
     // [START get_collections]
     var sfRef = db.collection('cities').doc('SF');
     sfRef.getCollections().then(collections => {
-        collections.forEach(colleciton => {
+        collections.forEach(collection => {
             console.log('Found subcollection with id:', collection.id);
         });
     });


### PR DESCRIPTION
On line 567, the argument 'colleciton' is passed as an argument into the forEach function.
The argument should be 'collection', just a small typo.

I've went ahead and fixed this typo.