### PR TITLE
Fix misleading example

### DIFF
--- a/firestore/main/index.js
+++ b/firestore/main/index.js
@@ -336,9 +336,7 @@ function updateNested(db) {
   // [END_EXCLUDE]
   var updateNested = db.collection('users').doc('Frank').update({
     age: 13,
-    favorites: {
-      color: 'Red'
-    }
+    'favorites.color': 'Red'
   });
   // [END update_nested]
 


### PR DESCRIPTION
Fix update_nested example as the documentation tells about the "dot notation":

> If your document contains nested objects, you can use "dot notation" to reference nested fields within the document when you call update()

https://firebase.google.com/docs/firestore/manage-data/add-data#update_fields_in_nested_objects