### PR TITLE
Firestore server-side deletes solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ keyfile.json
 service-account.json
 
 .firebaserc
-firebase.json
 firebase-debug.log
 
 package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ service-account.json
 
 .firebaserc
 firebase.json
+firebase-debug.log
 
 package-lock.json
 lerna-debug.log

--- a/firestore/solution-deletes/README.md
+++ b/firestore/solution-deletes/README.md
@@ -1,0 +1,42 @@
+# Solution: Recursive Deletes
+
+This solution shows how to write a Cloud Function that deletes data
+in Cloud Firestore and securely call this function from your
+mobile app or website.
+
+## Setup
+
+### On your development machine
+
+  1. Set up your Firebase project in the `solution-deletes` directory
+     by running `firebase init`. This solution uses both Firebase Hosting
+     and Cloud Functions for Firebase.
+  1. Generate a Firebase token using the `firebase login:ci` command.
+  1. Add the token to your Cloud Functions runtime configuration using the
+     following command:
+     ```
+     firebase functions:config:set fb.token="YOUR_TOKEN_HERE"
+     ```
+  1. Run `firebase deploy --only functions` to deploy the Cloud Functions.
+  1. Run `firebase serve --only hosting` to run a local version of the
+     application.
+
+### In your browser
+
+  1. Enable the **Identity and Access Management (IAM)** API on your project
+     in the Google Cloud console by visiting:
+     https://console.developers.google.com/apis/api/iam.googleapis.com/overview
+  1. In the [IAM page][iam-page] of the Google Cloud console, find the service account
+     called the "App Engine default service account" and grant it the
+     "Service Account Token Creator" role.
+
+## Usage
+
+  1. Visit `http://localhost:5000` to see the running sample.
+  1. Click the **SIGN IN** button. This will call the Cloud Function
+     you deployed to generate a custom sign in token, and then
+     use that token to sign in on the client.
+  1. Enter the path of the document or collection you would like
+     to delete, for example `things/thing1`, then click **DELETE**.
+
+[iam-page]: https://console.cloud.google.com/project/_/iam-admin

--- a/firestore/solution-deletes/firebase.json
+++ b/firestore/solution-deletes/firebase.json
@@ -1,0 +1,10 @@
+{
+  "hosting": {
+    "public": "public",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ]
+  }
+}

--- a/firestore/solution-deletes/functions/index.js
+++ b/firestore/solution-deletes/functions/index.js
@@ -24,23 +24,15 @@ exports.mintAdminToken = functions.https.onCall((data, context) => {
     });
 });
 
+// [START recursive_delete_function]
 /**
  * Initiate a recursive delete of documents at a given path.
  * 
- * This function first checks to make sure that the calling user is
- * authenticated and that the token has the custom "admin" attribute
- * set to true.
+ * The calling user must be authenticated and habe the custom "admin" attribute
+ * set to true on the auth token.
  * 
- * Next, the function calls the firestore:delet functionality
- * of the firebase-tools library to initiate a recursive delete.
  * This delete is NOT an atomic operation and it's possible
  * that it may fail after only deleting some documents.
- * 
- * Deployment notes:
- *   - The fb.token variable must be set in the functions config. This
- *     token can be obtained by running 'firebase login:ci'
- *   - The runtime options are set to the max timeout and RAM to allow
- *     for long-running delete operations of many documents.
  * 
  * @param {string} data.path the document or collection path to delete.
  */
@@ -63,7 +55,9 @@ exports.recursiveDelete = functions
       `User ${context.auth.uid} has requested to delete path ${path}`
     );
 
-    // Run a recursive delete on the given document or collection path/
+    // Run a recursive delete on the given document or collection path.
+    // The 'token' must be set in the functions config, and can be generated
+    // at the command line by running 'firebase login:ci'.
     return firebase_tools.firestore
       .delete(path, {
         project: process.env.GCLOUD_PROJECT,
@@ -72,6 +66,9 @@ exports.recursiveDelete = functions
         token: functions.config().fb.token
       })
       .then(() => {
-        return { path: path };
+        return {
+          path: path 
+        };
       });
   });
+  // [END recursive_delete_function]

--- a/firestore/solution-deletes/functions/index.js
+++ b/firestore/solution-deletes/functions/index.js
@@ -1,0 +1,77 @@
+const admin = require('firebase-admin');
+const firebase_tools = require('firebase-tools');
+const functions = require('firebase-functions');
+
+admin.initializeApp();
+
+/**
+ * Callable function that creates a custom auth token with the
+ * custom attribute "admin" set to true.
+ * 
+ * See https://firebase.google.com/docs/auth/admin/create-custom-tokens
+ * for more information on creating custom tokens.
+ * 
+ * @param {string} data.uid the user UID to set on the token.
+ */
+exports.mintAdminToken = functions.https.onCall((data, context) => {
+  const uid = data.uid;
+
+  return admin
+    .auth()
+    .createCustomToken(uid, { admin: true })
+    .then(function(token) {
+      return { token: token };
+    });
+});
+
+/**
+ * Initiate a recursive delete of documents at a given path.
+ * 
+ * This function first checks to make sure that the calling user is
+ * authenticated and that the token has the custom "admin" attribute
+ * set to true.
+ * 
+ * Next, the function calls the firestore:delet functionality
+ * of the firebase-tools library to initiate a recursive delete.
+ * This delete is NOT an atomic operation and it's possible
+ * that it may fail after only deleting some documents.
+ * 
+ * Deployment notes:
+ *   - The fb.token variable must be set in the functions config. This
+ *     token can be obtained by running 'firebase login:ci'
+ *   - The runtime options are set to the max timeout and RAM to allow
+ *     for long-running delete operations of many documents.
+ * 
+ * @param {string} data.path the document or collection path to delete.
+ */
+exports.recursiveDelete = functions
+  .runWith({
+    timeoutSeconds: 540,
+    memory: '2GB'
+  })
+  .https.onCall((data, context) => {
+    // Only allow admin users to execute this function.
+    if (!(context.auth && context.auth.token && context.auth.token.admin)) {
+      throw new functions.https.HttpsError(
+        'permission-denied',
+        'Must be an administrative user to initiate delete.'
+      );
+    }
+
+    const path = data.path;
+    console.log(
+      `User ${context.auth.uid} has requested to delete path ${path}`
+    );
+
+    // Run a recursive delete on the given document or collection path/
+    return firebase_tools.firestore
+      .delete(path, {
+        project: process.env.GCLOUD_PROJECT,
+        recursive: true,
+        yes: true,
+        token: functions.config().fb.token
+      })
+      .then(() => {
+        return { path: path };
+      });
+  });

--- a/firestore/solution-deletes/functions/package.json
+++ b/firestore/solution-deletes/functions/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "solution-deletes",
+  "version": "1.0.0",
+  "description": "Firestore delete data solution",
+  "main": "index.js",
+  "engines": {
+    "node": "8"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "firebase-admin": "^6.0.0",
+    "firebase-functions": "^2.0.5",
+    "firebase-tools": "^4.2.1"
+  }
+}

--- a/firestore/solution-deletes/public/index.css
+++ b/firestore/solution-deletes/public/index.css
@@ -1,0 +1,67 @@
+ body {
+    background: #ECEFF1;
+    color: rgba(0,0,0,0.87);
+    font-family: Roboto, Helvetica, Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+
+hr {
+    margin-top: 16px;
+    margin-bottom: 16px;
+}
+
+#form-signin {
+    display: grid;
+}
+
+#form-delete {
+    display: grid;
+    grid-template-rows: 1fr 1fr;
+}
+
+#message {
+    background: white;
+    max-width: 480px;
+    margin: 100px auto 16px;
+    padding: 32px 24px;
+    border-radius: 3px;
+}
+
+#message h2 {
+    color: #ffa100;
+    font-weight: bold;
+    font-size: 16px;
+    margin: 0 0 8px;
+}
+
+#message h1 {
+    font-size: 22px;
+    font-weight: 300;
+    color: rgba(0,0,0,0.6);
+    margin: 0 0 16px;
+}
+
+.btn {
+    border: none;
+    margin-top: 4px;
+    margin-bottom: 4px;
+
+    display: inline-block;
+    text-align: center;
+    background: #039be5;
+    text-transform: uppercase;
+    text-decoration: none;
+    color: white;
+    padding: 8px;
+    border-radius: 4px;
+}
+
+.btn:disabled {
+    background: #bdbdbd;
+    box-shadow: none;
+}
+
+.shadow {
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+}

--- a/firestore/solution-deletes/public/index.html
+++ b/firestore/solution-deletes/public/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Firestore - Delete Demo</title>
+
+    <script defer src="/__/firebase/5.5.1/firebase-app.js"></script>
+    <script defer src="/__/firebase/5.5.1/firebase-auth.js"></script>
+    <script defer src="/__/firebase/5.5.1/firebase-functions.js"></script>
+    <script defer src="/__/firebase/init.js"></script>
+
+    <link rel="stylesheet" href="index.css" />
+    <script defer src="index.js"></script>
+  </head>
+  <body>
+    <div id="message" class="shadow">
+      <h2>Cloud Firestore Demo</h2>
+      <h1>Server-Side Deletes</h1>
+      <p>Use the form below to initiate a delete.</p>
+
+      <div id="form-signin">
+        <input type="submit" class="btn shadow" id="btn-signin" value="Sign In">
+      </div>
+
+      <hr />
+
+      <div id="form-delete">
+        <input type="text" id="input-delete" placeholder="Path to delete...">
+        <input type="submit" class="btn shadow" id="btn-delete" value="Delete">
+      </div>
+
+    </div>
+  </body>
+</html>

--- a/firestore/solution-deletes/public/index.html
+++ b/firestore/solution-deletes/public/index.html
@@ -30,6 +30,12 @@
         <input type="submit" class="btn shadow" id="btn-delete" value="Delete">
       </div>
 
+
+      <p id="status">
+        Logs:
+        <ul id="log-list">
+        </ul>
+      </p>
     </div>
   </body>
 </html>

--- a/firestore/solution-deletes/public/index.js
+++ b/firestore/solution-deletes/public/index.js
@@ -1,0 +1,74 @@
+var firebase = firebase || {};
+
+/**
+ * Call the 'recursiveDelete' callable function with a path to initiate
+ * a server-side delete.
+ */
+function deleteAtPath(path) {
+    var deleteFn = firebase.functions().httpsCallable('recursiveDelete');
+    deleteFn({ path: path })
+        .then(function (result) {
+            console.log(result);
+        })
+        .catch(function (err) {
+            console.warn(err);
+        });
+}
+
+/**
+ * Call the 'mintAdminToken' callable function to get a custom token that
+ * makes us an admin user, then sign in.
+ */
+function signInAsAdmin() {
+    var tokenFn = firebase.functions().httpsCallable('mintAdminToken');
+    tokenFn({ uid: 'user1234' }).then(function (res) {
+        return firebase.auth().signInWithCustomToken(res.data.token);
+    });
+}
+
+/**
+ * Helper function: set the signed-in state of the UI.
+ */
+function setSignedIn(signedIn) {
+    console.log('Signed in: ' + signedIn);
+
+    setEnabled('input-delete', signedIn);
+    setEnabled('btn-delete', signedIn);
+    setEnabled('btn-signin', !signedIn);
+}
+
+/**
+ * Helper function: enable or disable a form element.
+ */
+function setEnabled(id, enabled) {
+    if (enabled) {
+        document.getElementById(id).removeAttribute('disabled');
+    } else {
+        document.getElementById(id).setAttribute('disabled', true);
+    }
+}
+
+/**
+ * Set up the UI:
+ *   - Click listeners.
+ *   - Auth state listener.
+ */
+document.addEventListener('DOMContentLoaded', function() {
+  firebase.auth().onAuthStateChanged(function(user) {
+    if (user) {
+      setSignedIn(true);
+    } else {
+      setSignedIn(false);
+    }
+  });
+
+  document.getElementById('btn-delete').addEventListener('click', function() {
+    var deleteInput = document.getElementById('input-delete');
+    var deletePath = deleteInput.value;
+    deleteAtPath(deletePath);
+  });
+
+  document.getElementById('btn-signin').addEventListener('click', function() {
+    signInAsAdmin();
+  });
+});

--- a/firestore/solution-deletes/public/index.js
+++ b/firestore/solution-deletes/public/index.js
@@ -1,5 +1,6 @@
 var firebase = firebase || {};
 
+// [START call_delete_function]
 /**
  * Call the 'recursiveDelete' callable function with a path to initiate
  * a server-side delete.
@@ -7,13 +8,15 @@ var firebase = firebase || {};
 function deleteAtPath(path) {
     var deleteFn = firebase.functions().httpsCallable('recursiveDelete');
     deleteFn({ path: path })
-        .then(function (result) {
-            console.log(result);
+        .then(function(result) {
+            logMessage('Delete success: ' + JSON.stringify(result));
         })
-        .catch(function (err) {
+        .catch(function(err) {
+            logMessage('Delete failed, see console,');
             console.warn(err);
         });
 }
+// [END call_delete_function]
 
 /**
  * Call the 'mintAdminToken' callable function to get a custom token that
@@ -30,11 +33,24 @@ function signInAsAdmin() {
  * Helper function: set the signed-in state of the UI.
  */
 function setSignedIn(signedIn) {
-    console.log('Signed in: ' + signedIn);
+    if (signedIn) {
+        logMessage('Signed in.');
+    } else {
+        logMessage('Not signed in.');
+    }
 
     setEnabled('input-delete', signedIn);
     setEnabled('btn-delete', signedIn);
     setEnabled('btn-signin', !signedIn);
+}
+
+/**
+ * Helper function: log a message to the UI.
+ */
+function logMessage(msg) {
+    var msgLi = document.createElement('li');
+    msgLi.innerText = msg;
+    document.getElementById('log-list').appendChild(msgLi);
 }
 
 /**


### PR DESCRIPTION
Demonstrates how to perform a recursive delete in a callable function and use it from the UI.

TODO:

- [x] Add `[START]` snippet tags
- [x] Add a `README`
- [ ] See if this can be done without the firebase token

Looks like this:
![image](https://user-images.githubusercontent.com/8466666/45910265-a3898480-bdbc-11e8-8bc4-9c9ca4d89dab.png)
