### PR TITLE
Support projectId for cloud functions

### DIFF
--- a/functions/firestore-export/index.js
+++ b/functions/firestore-export/index.js
@@ -9,8 +9,10 @@ const bucket = 'gs://BUCKET_NAME';
 exports.scheduledFirestoreExport = functions.pubsub
                                             .schedule('every 24 hours')
                                             .onRun((context) => {
+                                              
+  const projectId = process.env.GCP_PROJECT || process.env.GCLOUD_PROJECT;
   const databaseName = 
-    client.databasePath(process.env.GCP_PROJECT, '(default)');
+    client.databasePath(projectId, '(default)');
 
   return client.exportDocuments({
     name: databaseName,


### PR DESCRIPTION
I was following https://firebase.google.com/docs/firestore/solutions/schedule-export in order to export my firestore database, and I noticed that my projectId was undefined (resulting in `TypeError: Cannot read property 'charCodeAt' of undefined` from `google-gax`).

Don't know exactly when GCP_PROJECT is populated, but with this fix GCLOUD_PROJECT will be picked up for the cloud functions 🏄‍♂️