### PR TITLE
Removed duplicate generatePasswordResetLink

### DIFF
--- a/auth/email_action_links.js
+++ b/auth/email_action_links.js
@@ -31,27 +31,12 @@ admin
   .then((link) => {
     // Construct password reset email template, embed the link and send
     // using custom SMTP server.
-    return sendCustomPasswordResetEmail(email, displayName, link);
+    return sendCustomPasswordResetEmail(userEmail, displayName, link);
   })
   .catch((error) => {
     // Some error occurred.
   });
 // [END password_reset_link]
-
-// [START email_verification_link]
-// Admin SDK API to generate the password reset link.
-const email = 'user@example.com';
-admin
-  .auth()
-  .generatePasswordResetLink(email, actionCodeSettings)
-  .then((link) => {
-    // Construct password reset email template, embed the link and send
-    // using custom SMTP server.
-    return sendCustomPasswordResetEmail(email, displayName, link);
-  })
-  .catch((error) => {
-    // Some error occurred.
-  });
 
 // [START email_verification_link]
 // Admin SDK API to generate the email verification link.


### PR DESCRIPTION
The code for generating password reset link is being duplicated [here](https://firebase.google.com/docs/auth/admin/email-action-links#generate_email_verification_link) inside of "generate email verification link" block.

A screenshot for reference:
<img src="https://user-images.githubusercontent.com/63334359/121881903-7b40d180-cd2d-11eb-9ec5-6eed375dcd73.png" width="512">
