### PR TITLE
docs: fixed whitespace problem with snippet

### DIFF
--- a/firestore/main/index.js
+++ b/firestore/main/index.js
@@ -1,10 +1,8 @@
 const debug = require('debug')('firestore-snippets-node');
 
 // [START firestore_deps]
-// [START firestore_setup_client_create]
 const admin = require('firebase-admin');
 // [END firestore_deps]
-// [END firestore_setup_client_create]
 
 
 // We supress these logs when not in NODE_ENV=debug for cleaner Mocha output
@@ -12,6 +10,8 @@ const console = {log: debug};
 
 async function initializeAppWithProjectId() {
   // [START firestore_setup_client_create]
+  const admin = require('firebase-admin');
+
   admin.initializeApp({
     // The `projectId` parameter is optional and represents which project the
     // client will act on behalf of. If not supplied, it falls back to the default


### PR DESCRIPTION
fixes devsite rendering of snippet from this:

```js
const admin = require('firebase-admin');
  admin.initializeApp({
    // The `projectId` parameter is optional and represents which project the
    // client will act on behalf of. If not supplied, it falls back to the default
    // project inferred from the environment.
    projectId: 'my-project-id',
  });
  const db = admin.firestore();
```

to this

```js
const admin = require('firebase-admin');

admin.initializeApp({
  // The `projectId` parameter is optional and represents which project the
  // client will act on behalf of. If not supplied, it falls back to the default
  // project inferred from the environment.
  projectId: 'my-project-id',
});
const db = admin.firestore();
```