### PR TITLE
Updated email link snippet to use hosting

### DIFF
--- a/auth/email_action_links.js
+++ b/auth/email_action_links.js
@@ -18,8 +18,8 @@ const actionCodeSettings = {
     installApp: true,
     minimumVersion: '12',
   },
-  // FDL custom domain.
-  dynamicLinkDomain: 'coolapp.page.link',
+  // The domain must be configured in Firebase Hosting and owned by the project.
+  linkDomain: 'custom-domain.com',
 };
 // [END init_action_code_settings]
 


### PR DESCRIPTION
Updated email link snippet to use Firebase Hosting instead of Firebase Dynamic Links (deprecated).