### PR TITLE
feat: use native recursiveDelete for collection cleanup

### DIFF
--- a/firestore/main/index.js
+++ b/firestore/main/index.js
@@ -949,35 +949,7 @@ async function multipleCursorConditions(db) {
 // [START firestore_data_delete_collection]
 async function deleteCollection(db, collectionPath, batchSize) {
   const collectionRef = db.collection(collectionPath);
-  const query = collectionRef.orderBy('__name__').limit(batchSize);
-
-  return new Promise((resolve, reject) => {
-    deleteQueryBatch(db, query, resolve).catch(reject);
-  });
-}
-
-async function deleteQueryBatch(db, query, resolve) {
-  const snapshot = await query.get();
-
-  const batchSize = snapshot.size;
-  if (batchSize === 0) {
-    // When there are no documents left, we are done
-    resolve();
-    return;
-  }
-
-  // Delete documents in a batch
-  const batch = db.batch();
-  snapshot.docs.forEach((doc) => {
-    batch.delete(doc.ref);
-  });
-  await batch.commit();
-
-  // Recurse on the next process tick, to avoid
-  // exploding the stack.
-  process.nextTick(() => {
-    deleteQueryBatch(db, query, resolve);
-  });
+  return await db.recursiveDelete(collectionRef);
 }
 
 // [END firestore_data_delete_collection]

--- a/firestore/main/package.json
+++ b/firestore/main/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test-debug": "env DEBUG=firestore-snippets-node mocha index.js",
+    "test-debug": "env DEBUG=firestore-snippets-node mocha --timeout 20000 index.js",
     "test": "firebase --project=$GCLOUD_PROJECT emulators:exec './node_modules/.bin/mocha --timeout 20000 index.js'",
     "compile": "cp ../../tsconfig.template.json ./tsconfig.json && tsc"
   },


### PR DESCRIPTION
1. Update the Node.js sample code to utilize the native recursiveDelete method provided by the Firestore client library.
2. Increased Mocha timeout to 20s as the default was insufficient for Firestore emulator operations.